### PR TITLE
Fix: Only accept a default value of true or false if type is boolean

### DIFF
--- a/src/Console/Commands/MigrationBaseGenerator.php
+++ b/src/Console/Commands/MigrationBaseGenerator.php
@@ -74,7 +74,16 @@ class MigrationBaseGenerator extends Command
             if ($nullable) {
                 $default = null;
             } else {
-                $default = $this->ask('What is the default value of the field?');
+                // if type is boolean, the accepted value should either be true or false
+                if ($type === 'boolean') {
+                    $default = $this->ask('What is the default value of the field? (true/false)');
+                    while (!in_array($default, ['true', 'false'])) {
+                        $this->error("The {$default} value is not valid!. Accepted values are: true, false.");
+                        $default = $this->ask('What is the default value of the field? (true/false)');
+                    }
+                } else {
+                    $default = $this->ask('What is the default value of the field?');
+                }
             }
 
             $fields[] = [
@@ -126,7 +135,12 @@ class MigrationBaseGenerator extends Command
             }
 
             if (!empty($field['default'])) {
-                $fieldsString .= "->default('{$field['default']}')";
+                // if type is boolean, remove quotes from default value
+                if ($field['type'] == 'boolean') {
+                    $field['default'] = str_replace("'", '', $field['default']);
+                }else{
+                    $fieldsString .= "->default('{$field['default']}')";
+                }
             }
 
             $fieldsString .= ';' . PHP_EOL . "\t\t\t";


### PR DESCRIPTION
## Fix: Only accept a default value of true or false if type is boolean

### Description
This pull request fixes an issue where the package would accept default values for boolean types that were not `true` or `false`. With this fix, the package will now only accept a default value of `true` or `false` if the type is boolean.

### Changes
- Updated the validation logic to only accept a default value of `true` or `false` if the type is boolean.

### How to test
1. Initiate the process of creating a migration with ```php artisan codegen:migration --with-fields```.
1. Choose a data type of boolean on any column, make sure it's not nullable so that you are asked the default value.
1. Enter a default value you want, accepted values are `true` and `false`.
1. Verify that an error is thrown indicating that the default value specifies is invalid.