### PR TITLE
Add support to generate seeder from migration

### DIFF
--- a/src/Console/BaseTrait.php
+++ b/src/Console/BaseTrait.php
@@ -11,6 +11,17 @@ trait BaseTrait
         return dirname(__DIR__, 1) . "/{$path}";
     }
 
+    public function load_stub($name): string
+    {
+        if (str($name)->endsWith('.stub')){
+            $pos = strpos($name, '.stub');
+            $name = substr($name, 0, $pos);
+        }
+
+        $dir_name = dirname(__DIR__, 1) . "/stubs/{$name}.stub";
+        return file_get_contents($dir_name);
+    }
+
     public function snakeToCamelPlural($string): string
     {
         $string = str_replace('_', ' ', $string);

--- a/src/Console/Commands/Migrations/Migration.php
+++ b/src/Console/Commands/Migrations/Migration.php
@@ -6,16 +6,17 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Tgozo\LaravelCodegen\Console\Commands\Migrations\Traits\AddColumnsTrait;
 use Tgozo\LaravelCodegen\Console\Commands\Migrations\Traits\AddColumnTrait;
 use Tgozo\LaravelCodegen\Console\Commands\Migrations\Traits\CreateTrait;
+use Tgozo\LaravelCodegen\Console\Commands\Seeders\Traits\MethodsTrait;
 
 class Migration extends MigrationBaseGenerator
 {
-    use CreateTrait, AddColumnTrait, AddColumnsTrait;
+    use CreateTrait, AddColumnTrait, AddColumnsTrait, MethodsTrait;
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'codegen:migration {name?} {--m|m} {--c|c}';
+    protected $signature = 'codegen:migration {name?} {--m|m} {--c|c} {--s|s} {--all|all}';
 
     /**
      * The console command description.
@@ -41,6 +42,7 @@ class Migration extends MigrationBaseGenerator
      */
     public function handle(): void
     {
+
         $name = $this->getMigrationName();
 
         $pattern = $this->getPattern($name);

--- a/src/Console/Commands/Migrations/Traits/CreateTrait.php
+++ b/src/Console/Commands/Migrations/Traits/CreateTrait.php
@@ -12,19 +12,25 @@ trait CreateTrait
 
         $this->info("Migration [$created_migration_name] created successfully.");
 
-        if ($this->option('m')){
+        if ($this->option('m') || $this->option('all')){
             $modelName = $this->singularize(ucfirst($this->getTableName($name)));
             $created_model_name = $this->createModel($modelName, $fields);
             $this->info("Model [$created_model_name] created successfully.");
         }
 
-        if ($this->option('c')){
+        if ($this->option('c') || $this->option('all')){
             if (isset($modelName)){
                 $controllerName = $this->controller_name_from_model($modelName);
                 $created_controller_name = $this->createController($controllerName, $modelName, $fields, "standard");
                 $this->info("Controller [$created_controller_name] created successfully.");
                 $this->info("6 routes created in routes/web.php file.");
                 $this->info("4 views created in resources/views/{$this->str_to_lower($modelName)} directory.");
+            }
+        }
+
+        if ($this->option('s') || $this->option('all')){
+            if (isset($modelName)) {
+                $this->create_seeder($modelName, $fields);
             }
         }
     }

--- a/src/Console/Commands/Seeders/Seeder.php
+++ b/src/Console/Commands/Seeders/Seeder.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tgozo\LaravelCodegen\Console\Commands\Seeders;
+
+class Seeder extends SeederBaseGenerator
+{
+
+}

--- a/src/Console/Commands/Seeders/SeederBaseGenerator.php
+++ b/src/Console/Commands/Seeders/SeederBaseGenerator.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tgozo\LaravelCodegen\Console\Commands\Seeders;
+
+use Illuminate\Console\Command;
+
+class SeederBaseGenerator extends Command
+{
+
+}

--- a/src/Console/Commands/Seeders/Traits/MethodsTrait.php
+++ b/src/Console/Commands/Seeders/Traits/MethodsTrait.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tgozo\LaravelCodegen\Console\Commands\Seeders\Traits;
+
+use Tgozo\LaravelCodegen\Console\Commands\Migrations\Traits\AttributesTrait;
+use Tgozo\LaravelCodegen\Console\FakerGuesser;
+
+trait MethodsTrait
+{
+    use AttributesTrait;
+    public function get_seeder_string($modelName, $fields): string
+    {
+        if (empty($fields)){
+            return '//';
+        }
+        $str = "{$modelName}::insert([" . PHP_EOL;
+        foreach ($fields as $field) {
+            $name = $field['name'];
+            $type = $field['type'];
+            $guessed_output = FakerGuesser::guess($name, $type);
+            $guess = $guessed_output[0];
+
+            if ($name === 'password' or str($name)->contains('password')){
+                $str .= "\t\t\t'{$name}' => '{$guess}', // {$guessed_output[1]}";
+            }else{
+                $str .= "\t\t\t'{$name}' => $guess,";
+            }
+
+            $str .= PHP_EOL;
+        }
+        $str .= "\t\t]);";
+        return $str;
+    }
+
+    public function create_seeder($modelName, $fields = []): void
+    {
+        $seeder_name = $modelName . 'Seeder';
+        $database_seeder_file = database_path('seeders') . "/{$seeder_name}.php";
+        $function_name = 'run';
+        $new_code = $this->get_seeder_string($modelName, $fields);
+
+        $name_space = "Database\Seeders";
+
+        $stub = $this->load_stub('seeder.stub');
+
+        $stub = str_replace("{{ namespace }}", $name_space, $stub);
+
+        $stub = str_replace("{{ model }}", $modelName, $stub);
+
+        $stub = str_replace("{{ class }}", $seeder_name, $stub);
+
+        $function_pos = strpos($stub, "function $function_name");
+
+        $open_brace_pos = strpos($stub, '{', $function_pos);
+
+        $new_file_contents = substr_replace($stub, PHP_EOL . "\t\t$new_code", $open_brace_pos + 1, 0);
+
+        file_put_contents($database_seeder_file, $new_file_contents);
+
+        $this->info("Created Seeder {$seeder_name} at {$database_seeder_file}");
+        $this->register_seeder($modelName);
+    }
+
+    public function register_seeder($modelName): void
+    {
+        $seeder_name = $modelName . 'Seeder';
+        $file_name = 'DatabaseSeeder';
+        $database_seeder_file = database_path('seeders') . '/' . $file_name . '.php';
+        $function_name = 'run';
+        $new_code = "\$this->call({$seeder_name}::class);";
+
+        $file_contents = file_get_contents($database_seeder_file);
+
+        $function_pos = strpos($file_contents, "function $function_name");
+
+        $open_brace_pos = strpos($file_contents, '{', $function_pos);
+
+        $new_file_contents = substr_replace($file_contents, PHP_EOL . "\t\t$new_code", $open_brace_pos + 1, 0);
+
+        file_put_contents($database_seeder_file, $new_file_contents);
+
+        $this->info("Registered Seeder {$seeder_name} in {$file_name} file at {$database_seeder_file}");
+    }
+}

--- a/src/Console/FakerGuesser.php
+++ b/src/Console/FakerGuesser.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tgozo\LaravelCodegen\Console;
+
+use Illuminate\Support\Facades\Hash;
+
+class FakerGuesser
+{
+
+    public static array $common_returns = [
+        'name' => 'fake()->unique()->name',
+        'first_name' => 'fake()->unique()->firstName',
+        'last_name' => 'fake()->unique()->lastName',
+        'description' => 'fake()->unique()->text',
+        'body' => 'fake()->unique()->paragraph',
+        'title' => 'fake()->unique()->title',
+        'subject' => 'fake()->unique()->text(20)',
+        'message' => 'fake()->unique()->paragraph',
+        'cost' => 'fake()->unique()->randomNumber(4)',
+        'value' => 'fake()->unique()->randomNumber(4)',
+        'price' => 'fake()->unique()->randomNumber(4)',
+        'discount' => 'fake()->unique()->randomNumber(4)',
+        'qty' => 'fake()->unique()->randomNumber()',
+        'quantity' => 'fake()->unique()->randomNumber()',
+        'user' => 'fake()->unique()->randomNumber()',
+        'email' => 'fake()->unique()->safeEmail',
+        'password' => 'fake()->unique()->password',
+        'user_id' => 'fake()->unique()->randomNumber()',
+        'created_at' => 'now()',
+        'updated_at' => 'now()',
+        'deleted_at' => 'now()',
+        'email_verified_at' => 'now()',
+        'created_by' => 'fake()->unique()->randomNumber()',
+        'updated_by' => 'fake()->unique()->randomNumber()',
+        'deleted_by' => 'fake()->unique()->randomNumber()',
+        'country' => 'fake()->unique()->country',
+        'city' => 'fake()->unique()->city',
+        'currencyCode' => 'fake()->unique()->currencyCode',
+        'currency_code' => 'fake()->unique()->currencyCode',
+    ];
+
+    public static function guess($column_name, $column_type = "string"): array
+    {
+        $guess = self::fetch_guess($column_name, $column_type);
+        if ($column_name === 'password' or str($column_name)->contains('password')){
+            $initial_value = fake()->unique()->password;
+            $guess = Hash::make($initial_value);
+        }
+        return [$guess, $initial_value ?? ''];
+    }
+
+    public static function fetch_guess($column_name, mixed $column_type)
+    {
+        if (key_exists($column_name, self::$common_returns)) {
+            return self::$common_returns[$column_name];
+        }
+
+        if (str($column_name)->endsWith('at')) {
+            return 'now()';
+        }
+
+        if (str($column_name)->endsWith('by')) {
+            return 'fake()->unique()->randomNumber()';
+        }
+
+        if (str($column_name)->contains('password')) {
+            return 'fake()->unique()->password';
+        }
+
+        if ($column_type === 'integer') {
+            return 'fake()->randomNumber()';
+        }
+
+        return 'fake()->text';
+    }
+}

--- a/src/stubs/seeder.stub
+++ b/src/stubs/seeder.stub
@@ -4,6 +4,7 @@ namespace {{ namespace }};
 
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use App\Models\{{ model }};
 
 class {{ class }} extends Seeder
 {
@@ -12,6 +13,6 @@ class {{ class }} extends Seeder
      */
     public function run(): void
     {
-        //
+
     }
 }


### PR DESCRIPTION
This pull request adds support for the creation of a Seeder when using the `make:migration` command.

## Changes
- The `--s` or `-s` option has been added to create a Seeder when using the `make:migration` command.
- The Seeder will automatically be registered in the `DatabaseSeeder` file in the `database/seeders` directory.
- Support for the `--all` option has been added, which means all available options will be executed.

## Testing
To test these changes, you need to run the `make:migration` command with the `--s` or `-s` option and check if a Seeder has been created in the `database/seeders` directory and that the Seeder has been registered in the file `database/seeders/DatabaseSeeder.php`